### PR TITLE
2023-02-01-restricted-element-not-focusable

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
   </head>
   <body>
     <button type="button">Tabbable thing at top</button>
-    <div id="plain-div"><button type="button">First thing</button></div>
+    <div id="plain-div">
+      <button type="button" id="first-thing">First thing</button>
+    </div>
     <div id="app">
       <div id="first">
         <h1><button class="toggleFocus">Toggle focus</button> First</h1>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <title>restrict-focus</title>
   </head>
   <body>
+    <button type="button">Tabbable thing at top</button>
+    <div id="plain-div"><button type="button">First thing</button></div>
     <div id="app">
       <div id="first">
         <h1><button class="toggleFocus">Toggle focus</button> First</h1>

--- a/main.js
+++ b/main.js
@@ -21,10 +21,10 @@ if (!window.customElements.get("web-component-element")) {
 }
 
 window.addEventListener("restrict-focus:added", (e) => {
-  e.detail.style.boxShadow = "0 0 0 3px lime";
+  e.detail.element.style.boxShadow = "0 0 0 3px lime";
 });
 window.addEventListener("restrict-focus:removed", (e) => {
-  e.detail.style.boxShadow = "";
+  e.detail.element.style.boxShadow = "";
 });
 
 const registeredHotKeys = new Map();
@@ -126,8 +126,11 @@ document.querySelectorAll("button.toggleFocus").forEach((button) => {
   });
 });
 
-restrictFocus.add(document.getElementById("third"));
-restrictFocus.add(document.getElementById("second"), {
-  // Re-enable to test piercing the restriction via some event.
-  allowedEvents: ["mousedown", "mouseup", "click"],
-});
+setTimeout(() => {
+  restrictFocus.add(document.getElementById("plain-div"));
+  // restrictFocus.add(document.getElementById("third"));
+  // restrictFocus.add(document.getElementById("second"), {
+  //   // Re-enable to test piercing the restriction via some event.
+  //   allowedEvents: ["mousedown", "mouseup", "click"],
+  // });
+}, 2000);

--- a/main.js
+++ b/main.js
@@ -127,8 +127,8 @@ document.querySelectorAll("button.toggleFocus").forEach((button) => {
 });
 
 setTimeout(() => {
-  restrictFocus.add(document.getElementById("plain-div"));
-  // restrictFocus.add(document.getElementById("third"));
+  // restrictFocus.add(document.getElementById("plain-div"));
+  restrictFocus.add(document.getElementById("third"));
   // restrictFocus.add(document.getElementById("second"), {
   //   // Re-enable to test piercing the restriction via some event.
   //   allowedEvents: ["mousedown", "mouseup", "click"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restrict-focus",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "A small library to restrict focus/tabbing to only within a specified element. Shadow DOM aware, so it works with web components.",
   "homepage": "https://github.com/nullset/restrict-focus",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   vite: ^2.6.4

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,8 @@ function handleKeyboardNavigation({
     // If we're blurring off something in the middle, then revert focus back to where we came from.
     default:
       event.preventDefault();
-      target?.focus();
+      console.log({ target });
+      if (target && ![window, document].includes(target)) target.focus();
       break;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,7 @@ function handleKeyboardNavigation({
     // If we're blurring off something in the middle, then revert focus back to where we came from.
     default:
       event.preventDefault();
-      console.log({ target });
+      // Handle FF issue where it's possible to focus on either the window or the document.
       if (target && ![window, document].includes(target)) target.focus();
       break;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -373,8 +373,10 @@ const restrictFocus = {
         // (while -1 technically is able, it does not change the *NEXT* item to be focused on).
         restrictFocus.activeElement.tabIndex = 0;
         restrictFocus.activeElement.focus();
-        // Revert tabIndex to original value.
-        restrictFocus.activeElement.tabIndex = originalTabIndex;
+        // Revert tabIndex to original value. Wait a tick to ensure that `.focus()` above has been applied.
+        queueMicrotask(() => {
+          restrictFocus.activeElement.tabIndex = originalTabIndex;
+        });
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,15 @@ function handleBlur(event) {
   }
 }
 
+function handleFocus(event) {
+  if (
+    restrictFocus.activeElement &&
+    !restrictFocus.activeElement.contains(event.target)
+  ) {
+    restrictFocus.activeElement.focus();
+  }
+}
+
 function handleKeyboardNavigation({
   event,
   target,
@@ -422,7 +431,7 @@ const restrictFocus = {
 window.addEventListener("keydown", handleKeyDown, { capture: true });
 window.addEventListener("keyup", handleKeyUp, { capture: true });
 window.addEventListener("blur", handleBlur, { capture: true });
-// window.addEventListener("focus", preventFocusChange, { capture: true });
+window.addEventListener("focusin", handleFocus, { capture: true });
 window.addEventListener("mousedown", preventOutsideEvent, {
   capture: true,
 });


### PR DESCRIPTION
Fix a couple of issues:

* it's possible to get into a weird state when tabbing from the restricted area to browser chrome and then back to the page. Fix this so that the restricted area becomes the thing that is focused on when tabbing from browser chrome back to the page.
* Fix FF issue that was allowing focus to escape the restricted area
* When a restricted area is defined, ensure that that area becomes the element with focus automatically. 